### PR TITLE
Fix PlaceholderAPI breaks HEX Colors

### DIFF
--- a/src/main/java/me/wikmor/lpc/LPChatPlugin.java
+++ b/src/main/java/me/wikmor/lpc/LPChatPlugin.java
@@ -26,10 +26,13 @@ public final class LPChatPlugin extends JavaPlugin implements Listener {
 
 	private LuckPerms luckPerms;
 	
+	private boolean papi;
+	
 	@Override
 	public void onEnable() {
 		// Load an instance of 'LuckPerms' using the services manager.
 		this.luckPerms = getServer().getServicesManager().load(LuckPerms.class);
+		this.papi = getServer().getPluginManager().isPluginEnabled("PlaceholderAPI");
 
 		saveDefaultConfig();
 		getServer().getPluginManager().registerEvents(this, this);
@@ -74,8 +77,11 @@ public final class LPChatPlugin extends JavaPlugin implements Listener {
 				.replace("{displayname}", player.getDisplayName())
 				.replace("{username-color}", metaData.getMetaValue("username-color") != null ? metaData.getMetaValue("username-color") : "")
 				.replace("{message-color}", metaData.getMetaValue("message-color") != null ? metaData.getMetaValue("message-color") : "");
-
-		format = translateHexColorCodes(colorize(getServer().getPluginManager().isPluginEnabled("PlaceholderAPI") ? PlaceholderAPI.setPlaceholders(player, format) : format));
+		
+		format = translateHexColorCodes(colorize(format));
+		
+		if(papi)
+			format = PlaceholderAPI.setPlaceholders(player, format);
 
 		event.setFormat(format.replace("{message}", player.hasPermission("lpc.colorcodes") && player.hasPermission("lpc.rgbcodes")
 				? translateHexColorCodes(colorize(message)) : player.hasPermission("lpc.colorcodes") ? colorize(message) : player.hasPermission("lpc.rgbcodes")


### PR DESCRIPTION
When using &x&1&2&3&4&5&6 (Bukkit default) format, calling PlaceholderAPI#setPlaceholders first breaks the format:
![image](https://user-images.githubusercontent.com/20637793/156919792-e1d5cb5c-c672-4f53-8979-051f1da8ae74.png)
After this commit:
![image](https://user-images.githubusercontent.com/20637793/156919802-7608d81a-9498-4906-b7e8-cbf1868170a1.png)
